### PR TITLE
Attacher nodes instead of events permission

### DIFF
--- a/csi_rbac.tf
+++ b/csi_rbac.tf
@@ -106,7 +106,7 @@ resource "kubernetes_cluster_role" "attacher" {
 
   rule {
     api_groups = [""]
-    resources  = ["events"]
+    resources  = ["nodes"]
     verbs      = ["get", "list", "watch"]
   }
 


### PR DESCRIPTION
According the official templates this should be
nodes and not events.

Ref: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/deploy/kubernetes/base/clusterrole-attacher.yaml#L14