### PR TITLE
Ignore annotation changes to ds node field.cattle.io/publicEndpoints

### DIFF
--- a/node.tf
+++ b/node.tf
@@ -4,6 +4,12 @@ resource "kubernetes_daemonset" "node" {
     namespace = var.namespace
   }
 
+  lifecycle {
+    ignore_changes = [
+      metadata[0].annotations["field.cattle.io/publicEndpoints"],
+    ]
+  }
+
   spec {
     selector {
       match_labels = {


### PR DESCRIPTION
When using Rancher the annotation is changing often and causes
the terraform plan force to remove the annotation.