### PR TITLE
Allow specifying location of CSI controller image

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ module "ebs_csi_driver_controller" {
   source = "DrFaust92/ebs-csi-driver/kubernetes"
   version = "<VERSION>"
 
+  ebs_csi_controller_image                   = ""
   ebs_csi_controller_role_name               = "ebs-csi-driver-controller"
   ebs_csi_controller_role_policy_name_prefix = "ebs-csi-driver-policy"
   oidc_url                                   = aws_iam_openid_connect_provider.openid_connect.url
@@ -64,6 +65,7 @@ module "ebs_csi_driver_controller" {
 |------|-------------|------|---------|:--------:|
 | csi\_controller\_replica\_count | Number of EBS CSI driver controller pods | `number` | `2` | no |
 | csi\_controller\_tolerations | CSI driver controller tolerations | `list(map(string))` | `[]` | no |
+| ebs\_csi\_controller\_image | The EBS CSI driver controller's image | `string` | `""` | no |
 | ebs\_csi\_controller\_role\_name | The name of the EBS CSI driver IAM role | `string` | `"ebs-csi-driver-controller"` | no |
 | ebs\_csi\_controller\_role\_policy\_name\_prefix | The prefix of the EBS CSI driver IAM policy | `string` | `"ebs-csi-driver-policy"` | no |
 | eks\_cluster\_id | ID of the Kubernetes cluster used for tagging provisioned EBS volumes | `string` | `""` | no |

--- a/controller.tf
+++ b/controller.tf
@@ -45,7 +45,7 @@ resource "kubernetes_deployment" "ebs_csi_controller" {
 
         container {
           name  = "ebs-plugin"
-          image = var.ebs_csi_controller_image != "" ? "amazon/aws-ebs-csi-driver:${local.ebs_csi_driver_version}" : var.ebs_csi_controller_image
+          image = "${var.ebs_csi_controller_image == "" ? "amazon/aws-ebs-csi-driver" : var.ebs_csi_controller_image}:${local.ebs_csi_driver_version}"
           args = compact(
             [
               "--endpoint=$(CSI_ENDPOINT)",

--- a/controller.tf
+++ b/controller.tf
@@ -45,7 +45,7 @@ resource "kubernetes_deployment" "ebs_csi_controller" {
 
         container {
           name  = "ebs-plugin"
-          image = "amazon/aws-ebs-csi-driver:${local.ebs_csi_driver_version}"
+          image = var.ebs_csi_controller_image != "" ? "amazon/aws-ebs-csi-driver:${local.ebs_csi_driver_version}" : var.ebs_csi_controller_image
           args = compact(
             [
               "--endpoint=$(CSI_ENDPOINT)",

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,12 @@ variable "ebs_csi_controller_role_policy_name_prefix" {
   type        = string
 }
 
+variable "ebs_csi_controller_image" {
+  description = "The EBS CSI driver controller's image"
+  default     = ""
+  type        = string
+}
+
 variable "tags" {
   description = "A map of tags to add to all resources"
   default     = {}


### PR DESCRIPTION
We were using this module to run things on our cluster and found that we were running into issues caused by Docker Hub image pull rate limits when our pods restarted.

This PR adds an optional variable which allows users to specify a custom location for the controller's image. This allows end users to inject their own docker image proxy location to avoid this rate limiting affecting their running clusters.