### PR TITLE
Support --volume-attach-limit flag

### DIFF
--- a/node.tf
+++ b/node.tf
@@ -65,12 +65,13 @@ resource "kubernetes_daemonset" "node" {
         container {
           name  = "ebs-plugin"
           image = "${var.ebs_csi_controller_image == "" ? "amazon/aws-ebs-csi-driver" : var.ebs_csi_controller_image}:${local.ebs_csi_driver_version}"
-          args = [
+          args = flatten([
             "node",
             "--endpoint=$(CSI_ENDPOINT)",
             "--logtostderr",
             "--v=${tostring(var.log_level)}",
-          ]
+            var.volume_attach_limit == -1 ? [] : ["--volume-attach-limit=${var.volume_attach_limit}"]
+          ])
 
           security_context {
             privileged = true

--- a/variables.tf
+++ b/variables.tf
@@ -104,3 +104,9 @@ variable "log_level" {
   default     = 5
   type        = number
 }
+
+variable "volume_attach_limit" {
+  description = "Configure maximum volume attachments per node. -1 means use default configuration"
+  default     = -1
+  type        = number
+}


### PR DESCRIPTION
@DrFaust92 

Hey, just adding in support for this flag, it was added in [this](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/522) PR

here is [the helm chart](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/271046d1be7507cc21717dbaf96e62d3de235700/charts/aws-ebs-csi-driver/templates/node.yaml#L67) for comparison 