### PR TITLE
Allow configuration of image version

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  ebs_csi_driver_version = "v0.8.1-amazonlinux"
+  ebs_csi_driver_version = var.ebs_csi_driver_version == "" ? "v0.8.1-amazonlinux" : var.ebs_csi_driver_version
   liveness_probe_version = "v2.2.0"
   controller_name        = "ebs-csi-controller"
   daemonset_name         = "ebs-csi-node"

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,12 @@ variable "ebs_csi_controller_role_policy_name_prefix" {
   type        = string
 }
 
+variable "ebs_csi_driver_version" {
+  description = "The EBS CSI driver controller's image version"
+  default     = ""
+  type        = string
+}
+
 variable "ebs_csi_controller_image" {
   description = "The EBS CSI driver controller's image"
   default     = ""


### PR DESCRIPTION
For example, in order to use this image. 

k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v0.8.1

ebs_csi_driver_version = v0.8.1
ebs_csi_controller_image = k8s.gcr.io/provider-aws/aws-ebs-csi-driver

Thank you @DrFaust92 