### PR TITLE
Don't apply match all toleration if specifying custom ones

### DIFF
--- a/controller.tf
+++ b/controller.tf
@@ -33,12 +33,8 @@ resource "kubernetes_deployment" "ebs_csi_controller" {
         automount_service_account_token = true
         priority_class_name             = "system-cluster-critical"
 
-        toleration {
-          operator = "Exists"
-        }
-
         dynamic "toleration" {
-          for_each = var.csi_controller_tolerations
+          for_each = length(var.csi_controller_tolerations) > 0 ? var.csi_controller_tolerations : [{ operator = "Exists" }]
           content {
             key                = lookup(toleration.value, "key", null)
             operator           = lookup(toleration.value, "operator", null)

--- a/node.tf
+++ b/node.tf
@@ -53,12 +53,8 @@ resource "kubernetes_daemonset" "node" {
         automount_service_account_token = true
         priority_class_name             = "system-node-critical"
 
-        toleration {
-          operator = "Exists"
-        }
-
         dynamic "toleration" {
-          for_each = var.node_tolerations
+          for_each = length(var.node_tolerations) > 0 ? var.csi_controller_tolerations : [{ operator = "Exists" }]
           content {
             key                = lookup(toleration.value, "key", null)
             operator           = lookup(toleration.value, "operator", null)


### PR DESCRIPTION
Based on https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/758

The "match all" toleration block doesn't play nice when specifying custom tolerations - it basically will nullify them.