### PR TITLE
replace k8s.gcr.io registry with registry.k8s.io in all images

### DIFF
--- a/controller.tf
+++ b/controller.tf
@@ -127,7 +127,7 @@ resource "kubernetes_deployment" "ebs_csi_controller" {
 
         container {
           name  = "csi-provisioner"
-          image = "k8s.gcr.io/sig-storage/csi-provisioner:${var.csi_provisioner_tag_version}"
+          image = "registry.k8s.io/sig-storage/csi-provisioner:${var.csi_provisioner_tag_version}"
           args = compact(
             [
               "--csi-address=$(ADDRESS)",
@@ -177,7 +177,7 @@ resource "kubernetes_deployment" "ebs_csi_controller" {
 
         container {
           name  = "liveness-probe"
-          image = "k8s.gcr.io/sig-storage/livenessprobe:${local.liveness_probe_version}"
+          image = "registry.k8s.io/sig-storage/livenessprobe:${local.liveness_probe_version}"
           args = [
             "--csi-address=/csi/csi.sock"
           ]

--- a/locals.tf
+++ b/locals.tf
@@ -7,11 +7,11 @@ locals {
 
   resizer_container = var.enable_volume_resizing ? [{
     name  = "csi-resizer",
-    image = "k8s.gcr.io/sig-storage/csi-resizer:v1.4.0"
+    image = "registry.k8s.io/sig-storage/csi-resizer:v1.4.0"
   }] : []
 
   snapshot_container = var.enable_volume_snapshot ? [{
     name  = "csi-snapshotter",
-    image = "k8s.gcr.io/sig-storage/csi-snapshotter:v6.0.1"
+    image = "registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1"
   }] : []
 }

--- a/node.tf
+++ b/node.tf
@@ -66,7 +66,7 @@ resource "kubernetes_daemonset" "node" {
 
         container {
           name  = "ebs-plugin"
-          image = "${var.ebs_csi_controller_image == "" ? "k8s.gcr.io/provider-aws/aws-ebs-csi-driver" : var.ebs_csi_controller_image}:${local.ebs_csi_driver_version}"
+          image = "${var.ebs_csi_controller_image == "" ? "registry.k8s.io/provider-aws/aws-ebs-csi-driver" : var.ebs_csi_controller_image}:${local.ebs_csi_driver_version}"
           args = flatten([
             "node",
             "--http-endpoint=:8080",
@@ -192,7 +192,7 @@ resource "kubernetes_daemonset" "node" {
 
         container {
           name  = "liveness-probe"
-          image = "k8s.gcr.io/sig-storage/livenessprobe:${local.liveness_probe_version}"
+          image = "registry.k8s.io/sig-storage/livenessprobe:${local.liveness_probe_version}"
           args = [
             "--csi-address=/csi/csi.sock"
           ]

--- a/variables.tf
+++ b/variables.tf
@@ -18,7 +18,7 @@ variable "ebs_csi_driver_version" {
 
 variable "ebs_csi_controller_image" {
   description = "The EBS CSI driver controller's image"
-  default     = "k8s.gcr.io/provider-aws/aws-ebs-csi-driver"
+  default     = "registry.k8s.io/provider-aws/aws-ebs-csi-driver"
   type        = string
 }
 


### PR DESCRIPTION
Update all container images to use registry.k8s.io rather than k8s.gcr.io.

See announcement: https://kubernetes.io/blog/2023/03/10/image-registry-redirect/