### PR TITLE
Make all images customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ module "ebs_csi_driver_controller" {
   source = "DrFaust92/ebs-csi-driver/kubernetes"
   version = "<VERSION>"
 
-  ebs_csi_controller_image                   = ""
   ebs_csi_controller_role_name               = "ebs-csi-driver-controller"
   ebs_csi_controller_role_policy_name_prefix = "ebs-csi-driver-policy"
   oidc_url                                   = aws_iam_openid_connect_provider.openid_connect.url
@@ -96,14 +95,23 @@ module "ebs_csi_driver_controller" {
 | <a name="input_controller_csi_snapshotter_resources"></a> [controller\_csi\_snapshotter\_resources](#input\_controller\_csi\_snapshotter\_resources) | The controller csi snapshotter resources | <pre>object({<br>    requests = map(string)<br>    limits   = map(string)<br>  })</pre> | <pre>{<br>  "limits": {},<br>  "requests": {}<br>}</pre> | no |
 | <a name="input_controller_ebs_plugin_resources"></a> [controller\_ebs\_plugin\_resources](#input\_controller\_ebs\_plugin\_resources) | The controller ebs plugin resources | <pre>object({<br>    requests = map(string)<br>    limits   = map(string)<br>  })</pre> | <pre>{<br>  "limits": {},<br>  "requests": {}<br>}</pre> | no |
 | <a name="input_controller_extra_node_selectors"></a> [controller\_extra\_node\_selectors](#input\_controller\_extra\_node\_selectors) | A map of extra node selectors for controller pods | `map(string)` | `{}` | no |
+| <a name="input_csi_attacher_image"></a> [csi\_attacher\_image](#input\_csi\_attacher\_image) | The CSI attacher image | `string` | `"registry.k8s.io/sig-storage/csi-attacher"` | no |
+| <a name="input_csi_attacher_version"></a> [csi\_attacher\_version](#input\_csi\_attacher\_version) | The CSI attacher image version | `string` | `"v3.5.1"` | no |
 | <a name="input_csi_controller_replica_count"></a> [csi\_controller\_replica\_count](#input\_csi\_controller\_replica\_count) | Number of EBS CSI driver controller pods | `number` | `2` | no |
 | <a name="input_csi_controller_tolerations"></a> [csi\_controller\_tolerations](#input\_csi\_controller\_tolerations) | CSI driver controller tolerations | `list(map(string))` | `[]` | no |
-| <a name="input_csi_provisioner_tag_version"></a> [csi\_provisioner\_tag\_version](#input\_csi\_provisioner\_tag\_version) | The csi provisioner tag version | `string` | `"v3.2.1"` | no |
+| <a name="input_csi_node_driver_registrar_image"></a> [csi\_node\_driver\_registrar\_image](#input\_csi\_node\_driver\_registrar\_image) | The CSI node driver registrar image | `string` | `"registry.k8s.io/sig-storage/csi-node-driver-registrar"` | no |
+| <a name="input_csi_node_driver_registrar_version"></a> [csi\_node\_driver\_registrar\_version](#input\_csi\_node\_driver\_registrar\_version) | The CSI node driver registrar image version | `string` | `"v2.9.0"` | no |
+| <a name="input_csi_provisioner_image"></a> [csi\_provisioner\_image](#input\_csi\_provisioner\_image) | The CSI provisioner image | `string` | `"registry.k8s.io/sig-storage/csi-provisioner"` | no |
+| <a name="input_csi_provisioner_tag_version"></a> [csi\_provisioner\_tag\_version](#input\_csi\_provisioner\_tag\_version) | The CSI provisioner tag version | `string` | `"v3.2.1"` | no |
+| <a name="input_csi_resizer_image"></a> [csi\_resizer\_image](#input\_csi\_resizer\_image) | The CSI resizer image | `string` | `"registry.k8s.io/sig-storage/csi-resizer"` | no |
+| <a name="input_csi_resizer_version"></a> [csi\_resizer\_version](#input\_csi\_resizer\_version) | The CSI resizer image version | `string` | `"v1.4.0"` | no |
+| <a name="input_csi_snapshotter_image"></a> [csi\_snapshotter\_image](#input\_csi\_snapshotter\_image) | The CSI snapshotter image | `string` | `"registry.k8s.io/sig-storage/csi-snapshotter"` | no |
+| <a name="input_csi_snapshotter_version"></a> [csi\_snapshotter\_version](#input\_csi\_snapshotter\_version) | The CSI snapshotter image version | `string` | `"v6.0.1"` | no |
 | <a name="input_default_fstype"></a> [default\_fstype](#input\_default\_fstype) | The default Filesystem type | `string` | `"ext4"` | no |
 | <a name="input_ebs_csi_controller_image"></a> [ebs\_csi\_controller\_image](#input\_ebs\_csi\_controller\_image) | The EBS CSI driver controller's image | `string` | `"k8s.gcr.io/provider-aws/aws-ebs-csi-driver"` | no |
 | <a name="input_ebs_csi_controller_role_name"></a> [ebs\_csi\_controller\_role\_name](#input\_ebs\_csi\_controller\_role\_name) | The name of the EBS CSI driver IAM role | `string` | `"ebs-csi-driver-controller"` | no |
 | <a name="input_ebs_csi_controller_role_policy_name_prefix"></a> [ebs\_csi\_controller\_role\_policy\_name\_prefix](#input\_ebs\_csi\_controller\_role\_policy\_name\_prefix) | The prefix of the EBS CSI driver IAM policy | `string` | `"ebs-csi-driver-policy"` | no |
-| <a name="input_ebs_csi_driver_version"></a> [ebs\_csi\_driver\_version](#input\_ebs\_csi\_driver\_version) | The EBS CSI driver controller's image version | `string` | `""` | no |
+| <a name="input_ebs_csi_driver_version"></a> [ebs\_csi\_driver\_version](#input\_ebs\_csi\_driver\_version) | The EBS CSI driver controller's image version | `string` | `"v1.6.2"` | no |
 | <a name="input_eks_cluster_id"></a> [eks\_cluster\_id](#input\_eks\_cluster\_id) | ID of the Kubernetes cluster used for tagging provisioned EBS volumes | `string` | `""` | no |
 | <a name="input_enable_default_fstype"></a> [enable\_default\_fstype](#input\_enable\_default\_fstype) | Wheter to enable default Filesystem type | `bool` | `false` | no |
 | <a name="input_enable_volume_resizing"></a> [enable\_volume\_resizing](#input\_enable\_volume\_resizing) | Whether to enable volume resizing | `bool` | `false` | no |
@@ -111,6 +119,8 @@ module "ebs_csi_driver_controller" {
 | <a name="input_extra_create_metadata"></a> [extra\_create\_metadata](#input\_extra\_create\_metadata) | If set, add pv/pvc metadata to plugin create requests as parameters. | `bool` | `false` | no |
 | <a name="input_extra_node_selectors"></a> [extra\_node\_selectors](#input\_extra\_node\_selectors) | A map of extra node selectors for all components | `map(string)` | `{}` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | A map of extra labels for all resources | `map(string)` | `{}` | no |
+| <a name="input_liveness_probe_image"></a> [liveness\_probe\_image](#input\_liveness\_probe\_image) | The liveness probe image | `string` | `"registry.k8s.io/sig-storage/livenessprobe"` | no |
+| <a name="input_liveness_probe_version"></a> [liveness\_probe\_version](#input\_liveness\_probe\_version) | The liveness probe image version | `string` | `"v2.5.0"` | no |
 | <a name="input_log_level"></a> [log\_level](#input\_log\_level) | The log level for the CSI Driver controller | `number` | `5` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | The K8s namespace for all EBS CSI driver resources | `string` | `"kube-system"` | no |
 | <a name="input_node_driver_registrar_resources"></a> [node\_driver\_registrar\_resources](#input\_node\_driver\_registrar\_resources) | The node driver registrar resources | <pre>object({<br>    requests = map(string)<br>    limits   = map(string)<br>  })</pre> | <pre>{<br>  "limits": {},<br>  "requests": {}<br>}</pre> | no |

--- a/controller.tf
+++ b/controller.tf
@@ -46,7 +46,7 @@ resource "kubernetes_deployment" "ebs_csi_controller" {
 
         container {
           name  = "ebs-plugin"
-          image = "${var.ebs_csi_controller_image}:${local.ebs_csi_driver_version}"
+          image = "${local.ebs_csi_controller_image}:${local.ebs_csi_driver_version}"
           args = compact(
             [
               "controller",
@@ -127,7 +127,7 @@ resource "kubernetes_deployment" "ebs_csi_controller" {
 
         container {
           name  = "csi-provisioner"
-          image = "registry.k8s.io/sig-storage/csi-provisioner:${var.csi_provisioner_tag_version}"
+          image = "${var.csi_provisioner_image}:${var.csi_provisioner_tag_version}"
           args = compact(
             [
               "--csi-address=$(ADDRESS)",
@@ -157,7 +157,7 @@ resource "kubernetes_deployment" "ebs_csi_controller" {
 
         container {
           name  = "csi-attacher"
-          image = "registry.k8s.io/sig-storage/csi-attacher:v3.5.1"
+          image = "${var.csi_attacher_image}:${var.csi_attacher_version}"
           args = [
             "--csi-address=$(ADDRESS)",
             "--v=${tostring(var.log_level)}",
@@ -177,7 +177,7 @@ resource "kubernetes_deployment" "ebs_csi_controller" {
 
         container {
           name  = "liveness-probe"
-          image = "registry.k8s.io/sig-storage/livenessprobe:${local.liveness_probe_version}"
+          image = "${var.liveness_probe_image}:${var.liveness_probe_version}"
           args = [
             "--csi-address=/csi/csi.sock"
           ]

--- a/locals.tf
+++ b/locals.tf
@@ -1,17 +1,19 @@
 locals {
-  ebs_csi_driver_version = var.ebs_csi_driver_version == "" ? "v1.6.2" : var.ebs_csi_driver_version
-  liveness_probe_version = "v2.5.0"
-  controller_name        = "ebs-csi-controller"
-  daemonset_name         = "ebs-csi-node"
-  csi_volume_tags        = join(",", [for key, value in var.tags : "${key}=${value}"])
+  controller_name = "ebs-csi-controller"
+  daemonset_name  = "ebs-csi-node"
+  csi_volume_tags = join(",", [for key, value in var.tags : "${key}=${value}"])
 
   resizer_container = var.enable_volume_resizing ? [{
     name  = "csi-resizer",
-    image = "registry.k8s.io/sig-storage/csi-resizer:v1.4.0"
+    image = "${var.csi_resizer_image}:${var.csi_resizer_version}"
   }] : []
 
   snapshot_container = var.enable_volume_snapshot ? [{
     name  = "csi-snapshotter",
-    image = "registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1"
+    image = "${var.csi_snapshotter_image}:${var.csi_snapshotter_version}"
   }] : []
+
+  # backwards compatibility: use default value when value is an empty string
+  ebs_csi_driver_version   = var.ebs_csi_driver_version == "" ? "v1.6.2" : var.ebs_csi_driver_version
+  ebs_csi_controller_image = var.ebs_csi_controller_image == "" ? "registry.k8s.io/provider-aws/aws-ebs-csi-driver" : var.ebs_csi_controller_image
 }

--- a/node.tf
+++ b/node.tf
@@ -66,7 +66,7 @@ resource "kubernetes_daemonset" "node" {
 
         container {
           name  = "ebs-plugin"
-          image = "${var.ebs_csi_controller_image == "" ? "registry.k8s.io/provider-aws/aws-ebs-csi-driver" : var.ebs_csi_controller_image}:${local.ebs_csi_driver_version}"
+          image = "${local.ebs_csi_controller_image}:${local.ebs_csi_driver_version}"
           args = flatten([
             "node",
             "--http-endpoint=:8080",
@@ -149,7 +149,7 @@ resource "kubernetes_daemonset" "node" {
 
         container {
           name  = "node-driver-registrar"
-          image = "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.0"
+          image = "${var.csi_node_driver_registrar_image}:${var.csi_node_driver_registrar_version}"
           args = [
             "--csi-address=$(ADDRESS)",
             "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)",
@@ -192,7 +192,7 @@ resource "kubernetes_daemonset" "node" {
 
         container {
           name  = "liveness-probe"
-          image = "registry.k8s.io/sig-storage/livenessprobe:${local.liveness_probe_version}"
+          image = "${var.liveness_probe_image}:${var.liveness_probe_version}"
           args = [
             "--csi-address=/csi/csi.sock"
           ]

--- a/variables.tf
+++ b/variables.tf
@@ -10,15 +10,89 @@ variable "ebs_csi_controller_role_policy_name_prefix" {
   type        = string
 }
 
+# for backwards compatibility see locals.tf
 variable "ebs_csi_driver_version" {
   description = "The EBS CSI driver controller's image version"
-  default     = ""
+  default     = "v1.6.2"
   type        = string
 }
 
+# for backwards compatibility see locals.tf
 variable "ebs_csi_controller_image" {
   description = "The EBS CSI driver controller's image"
   default     = "registry.k8s.io/provider-aws/aws-ebs-csi-driver"
+  type        = string
+}
+
+variable "csi_node_driver_registrar_version" {
+  description = "The CSI node driver registrar image version"
+  default     = "v2.9.0"
+  type        = string
+}
+
+variable "csi_node_driver_registrar_image" {
+  description = "The CSI node driver registrar image"
+  default     = "registry.k8s.io/sig-storage/csi-node-driver-registrar"
+  type        = string
+}
+
+variable "csi_attacher_version" {
+  description = "The CSI attacher image version"
+  default     = "v3.5.1"
+  type        = string
+}
+
+variable "csi_attacher_image" {
+  description = "The CSI attacher image"
+  default     = "registry.k8s.io/sig-storage/csi-attacher"
+  type        = string
+}
+
+variable "csi_provisioner_tag_version" {
+  description = "The csi provisioner tag version"
+  default     = "v3.2.1"
+  type        = string
+}
+
+variable "csi_provisioner_image" {
+  description = "The CSI provisioner image"
+  default     = "registry.k8s.io/sig-storage/csi-provisioner"
+  type        = string
+}
+
+variable "csi_resizer_version" {
+  description = "The CSI resizer image version"
+  default     = "v1.4.0"
+  type        = string
+}
+
+variable "csi_resizer_image" {
+  description = "The CSI resizer image"
+  default     = "registry.k8s.io/sig-storage/csi-resizer"
+  type        = string
+}
+
+variable "csi_snapshotter_version" {
+  description = "The CSI snapshotter image version"
+  default     = "v6.0.1"
+  type        = string
+}
+
+variable "csi_snapshotter_image" {
+  description = "The CSI snapshotter image"
+  default     = "registry.k8s.io/sig-storage/csi-snapshotter"
+  type        = string
+}
+
+variable "liveness_probe_version" {
+  description = "The liveness probe image version"
+  default     = "v2.5.0"
+  type        = string
+}
+
+variable "liveness_probe_image" {
+  description = "The liveness probes image"
+  default     = "registry.k8s.io/sig-storage/livenessprobe"
   type        = string
 }
 
@@ -132,12 +206,6 @@ variable "enable_default_fstype" {
 variable "default_fstype" {
   description = "The default Filesystem type"
   default     = "ext4"
-  type        = string
-}
-
-variable "csi_provisioner_tag_version" {
-  description = "The csi provisioner tag version"
-  default     = "v3.2.1"
   type        = string
 }
 


### PR DESCRIPTION
In certain environments images need to be customized (cache, air-gapped,
etc.). This allows to customize all images while remaining backwards
compatible, supporting default values for an empty string variable
input of old variables.
