### PR TITLE
Configurable pre-stop hooks for node daemonset

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -17,6 +17,17 @@ data "aws_iam_policy_document" "ebs_controller_policy" {
     ]
   }
 
+  # https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/2190
+  statement {
+    effect = "Allow"
+
+    resources = [
+      "arn:${var.arn_format}:ec2:*:*:snapshot/*",
+    ]
+
+    actions = ["ec2:CreateVolume"]
+  }
+
   statement {
     effect = "Allow"
 

--- a/node-rbac.tf
+++ b/node-rbac.tf
@@ -16,6 +16,18 @@ resource "kubernetes_cluster_role" "node" {
   rule {
     api_groups = [""]
     resources  = ["nodes"]
+    verbs      = ["get", "patch"]
+  }
+
+  rule {
+    api_groups = ["storage.k8s.io"]
+    resources  = ["volumeattachments"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = ["storage.k8s.io"]
+    resources  = ["csinodes"]
     verbs      = ["get"]
   }
 }

--- a/node.tf
+++ b/node.tf
@@ -54,7 +54,7 @@ resource "kubernetes_daemonset" "node" {
         priority_class_name             = "system-node-critical"
 
         dynamic "toleration" {
-          for_each = length(var.node_tolerations) > 0 ? var.csi_controller_tolerations : [{ operator = "Exists" }]
+          for_each = var.node_tolerations
           content {
             key                = lookup(toleration.value, "key", null)
             operator           = lookup(toleration.value, "operator", null)

--- a/node.tf
+++ b/node.tf
@@ -76,6 +76,17 @@ resource "kubernetes_daemonset" "node" {
             var.volume_attach_limit == -1 ? [] : ["--volume-attach-limit=${var.volume_attach_limit}"]
           ])
 
+          dynamic "lifecycle" {
+            for_each = var.ebs_csi_plugin_pre_stop_command != null ? [1] : []
+            content {
+              pre_stop {
+                exec {
+                  command = var.ebs_csi_plugin_pre_stop_command
+                }
+              }
+            }
+          }
+
           security_context {
             privileged = true
           }
@@ -156,10 +167,13 @@ resource "kubernetes_daemonset" "node" {
             "--v=${tostring(var.log_level)}",
           ]
 
-          lifecycle {
-            pre_stop {
-              exec {
-                command = ["/bin/sh", "-c", "rm -rf /registration/ebs.csi.aws.com-reg.sock /csi/csi.sock"]
+          dynamic "lifecycle" {
+            for_each = var.ebs_csi_registrar_pre_stop_command != null ? [1] : []
+            content {
+              pre_stop {
+                exec {
+                  command = var.ebs_csi_registrar_pre_stop_command
+                }
               }
             }
           }

--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,12 @@ variable "ebs_csi_controller_image" {
   type        = string
 }
 
+variable "ebs_csi_plugin_pre_stop_command" {
+  type = list(string)
+  default = ["/bin/aws-ebs-csi-driver", "pre-stop-hook"]
+  description = "The pre-stop command for the EBS CSI driver plugin container"
+}
+
 variable "csi_node_driver_registrar_version" {
   description = "The CSI node driver registrar image version"
   default     = "v2.9.0"
@@ -34,6 +40,12 @@ variable "csi_node_driver_registrar_image" {
   description = "The CSI node driver registrar image"
   default     = "registry.k8s.io/sig-storage/csi-node-driver-registrar"
   type        = string
+}
+
+variable "ebs_csi_registrar_pre_stop_command" {
+  type = list(string)
+  default = null
+  description = "The pre-stop command for the EBS CSI driver registrar container"
 }
 
 variable "csi_attacher_version" {

--- a/variables.tf
+++ b/variables.tf
@@ -128,7 +128,7 @@ variable "oidc_url" {
 variable "node_tolerations" {
   description = "CSI driver node tolerations"
   type        = list(map(string))
-  default     = []
+  default     = [{ operator = "Exists" }]
 }
 
 variable "csi_controller_tolerations" {

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,13 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    kubernetes = ">= 1.11.4"
-    aws        = ">= 3.40.0"
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.0.0"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
   }
 }


### PR DESCRIPTION
Here are a few changes needed to deal with volume multi-attach error when using karpenter with ebs-csi-driver in eks cluster.
1. Actualize node cluster-role permissions
2. Allow empty tolerations for node daemonset, so karpenter will evict it on node shutdown
3. Make preStop hooks for node containers configurable. Firstly, I added aws-ebs-csi-driver pre-stop-hook by deafult in `ebs-plugin` container, secondly it is now possible to make sleep pre-stop hook for `node-driver-registrar` container to give time for others pods to unmount volumes. I did not add this pre-stop hook in defaults because default image is distroless and does not have `sleep` available (also for this reason current pre-stop hook is always failing)